### PR TITLE
Refactor: Simplify entity by removing unused setter methods

### DIFF
--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -10,16 +10,16 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 class Comment
 {
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private readonly int $id;
     
     #[ORM\Column]
     private readonly \DateTimeImmutable $createdAt;
 
     public function __construct(
-        #[ORM\Id]
-        #[ORM\GeneratedValue]
-        #[ORM\Column]
-        private readonly int $id,
-    
         #[Assert\NotBlank]
         #[Assert\Length(max: 255)]
         #[ORM\Column(length: 255)]

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -10,34 +10,35 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 class Comment
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column]
-    private readonly int $id;
-
-    #[Assert\NotBlank]
-    #[Assert\Length(max: 255)]
-    #[ORM\Column(length: 255)]
-    private ?string $postUrl = null;
-
-    #[Assert\NotBlank]
-    #[Assert\Length(max: 255)]
-    #[ORM\Column(length: 255)]
-    private ?string $name = null;
-
-    #[Assert\Length(max: 255)]
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $email = null;
-
-    #[Assert\NotBlank]
-    #[ORM\Column(type: Types::TEXT)]
-    private ?string $comment = null;
-
+    
     #[ORM\Column]
     private readonly \DateTimeImmutable $createdAt;
 
-    public function __construct()
-    {
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\GeneratedValue]
+        #[ORM\Column]
+        private readonly int $id,
+    
+        #[Assert\NotBlank]
+        #[Assert\Length(max: 255)]
+        #[ORM\Column(length: 255)]
+        private ?string $postUrl = null,
+    
+        #[Assert\NotBlank]
+        #[Assert\Length(max: 255)]
+        #[ORM\Column(length: 255)]
+        private ?string $name = null,
+    
+        #[Assert\Length(max: 255)]
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $email = null,
+    
+        #[Assert\NotBlank]
+        #[ORM\Column(type: Types::TEXT)]
+        private ?string $comment = null,
+        ){
+            
         $this->createdAt = new \DateTimeImmutable();
     }
 
@@ -51,23 +52,9 @@ class Comment
         return $this->postUrl;
     }
 
-    public function setPostUrl(string $postUrl): static
-    {
-        $this->postUrl = $postUrl;
-
-        return $this;
-    }
-
     public function getName(): ?string
     {
         return $this->name;
-    }
-
-    public function setName(string $name): static
-    {
-        $this->name = $name;
-
-        return $this;
     }
 
     public function getEmail(): ?string
@@ -75,23 +62,10 @@ class Comment
         return $this->email;
     }
 
-    public function setEmail(?string $email): static
-    {
-        $this->email = $email;
-
-        return $this;
-    }
 
     public function getComment(): ?string
     {
         return $this->comment;
-    }
-
-    public function setComment(string $comment): static
-    {
-        $this->comment = $comment;
-
-        return $this;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -37,7 +37,6 @@ class Comment
         #[ORM\Column(type: Types::TEXT)]
         private ?string $comment = null,
         ){
-            
         $this->createdAt = new \DateTimeImmutable();
     }
 

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -10,7 +10,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 class Comment
 {
-
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]


### PR DESCRIPTION
Sadly I don't think we can get rid of the getters because they are called by the symphony serializer. And we can't just make the properties public because that won't work with Doctrine proxy objects.

Untested code. But this should also now make it easier to write tests, since the constructor now tells you what properties a comment needs, and you don't have to remember to call multiple setter functions.